### PR TITLE
Removed hard coded spark submit path from run-server

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -3,7 +3,7 @@ JAR=server/target/scala-2.10/gt-admin-server-assembly-0.1.0-SNAPSHOT.jar
 zip -d $JAR META-INF/ECLIPSEF.RSA
 zip -d $JAR META-INF/ECLIPSEF.SF
 
-/usr/local/Cellar/apache-spark/1.1.1/bin/spark-submit \
+spark-submit \
 --class geotrellis.admin.server.CatalogService \
 --conf spark.executor.memory=8g --master local[4] --driver-memory=2g \
 $JAR \


### PR DESCRIPTION
(Small PR, wanted to get practice with the work flow)
In ingest-spatial.sh we simply use "submit spark" with no path, so I've mirrored that behavior in run-server.sh and removed the original hard coded Mac path. 