### PR TITLE
Show broken metadata

### DIFF
--- a/client/src/main/resources/index-dev.html
+++ b/client/src/main/resources/index-dev.html
@@ -31,12 +31,15 @@
 
   <section class="app"></section>
 
-  <!-- An extra dependency -->
+  <!-- Deps -->
+  <script type="text/javascript" src="../../../target/scala-2.11/geotrellis-admin-client-jsdeps.js"></script>
+  <script type="text/javascript" src="../../../target/scala-2.11/classes/index-bundle.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/4.0.1/placeholders.js"></script>
+
+  <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 
   <!-- Include Scala.js compiled code -->
   <script type="text/javascript" src="../../../target/scala-2.11/geotrellis-admin-client-fastopt.js"></script>
-  <script type="text/javascript" src="../../../target/scala-2.11/geotrellis-admin-client-jsdeps.js"></script>
 
   <!-- Run the App -->
   <script type="text/javascript" src="../../../target/scala-2.11/geotrellis-admin-client-launcher.js"></script>

--- a/client/src/main/scala/geotrellis/admin/client/circuit/Circuit.scala
+++ b/client/src/main/scala/geotrellis/admin/client/circuit/Circuit.scala
@@ -43,8 +43,8 @@ class DisplayHandler[M](modelRW: ModelRW[M, DisplayModel]) extends ActionHandler
         val parsed: js.Any = JSON.parse(res.responseText)
 
         decodeJs[Metadata](parsed) match {
-          case Xor.Right(m) => UpdateMetadata(Ready(m))
-          case Xor.Left(e) => UpdateMetadata(Failed(e))
+          case Xor.Right(m) => UpdateMetadata(Ready(m), Ready(res.responseText))
+          case Xor.Left(e) => UpdateMetadata(Failed(e), Ready(res.responseText))
         }
       }))
     }
@@ -58,7 +58,7 @@ class DisplayHandler[M](modelRW: ModelRW[M, DisplayModel]) extends ActionHandler
         }
       }))
     }
-    case UpdateMetadata(md) => updated(value.copy(metadata = md))
+    case UpdateMetadata(md, json) => updated(value.copy(metadata = md, rawMetadata = json))
     case UpdateAttributes(attrs) => updated(value.copy(attributes = attrs))
   }
 }

--- a/client/src/main/scala/geotrellis/admin/client/circuit/Model.scala
+++ b/client/src/main/scala/geotrellis/admin/client/circuit/Model.scala
@@ -48,6 +48,7 @@ case class DisplayModel(
   opacity: Option[Int] = None,
   breaksCount: Option[Int] = None,
   metadata: Pot[Metadata] = Empty,
+  rawMetadata: Pot[String] = Empty,
   attributes: Pot[ExtraAttrs] = Empty,
   leafletM: LeafletModel = LeafletModel()
 )
@@ -69,7 +70,7 @@ case class UpdateBreaks(breaks: Pot[String] = Empty)
 case object RefreshBreaks
 
 /* Metadata */
-case class UpdateMetadata(md: Pot[Metadata] = Empty)
+case class UpdateMetadata(md: Pot[Metadata] = Empty, json: Pot[String] = Empty)
 case object CollectMetadata
 
 /* Extra Attributes */

--- a/client/src/main/scala/geotrellis/admin/client/routes/GeotrellisAdminViewer.scala
+++ b/client/src/main/scala/geotrellis/admin/client/routes/GeotrellisAdminViewer.scala
@@ -13,7 +13,7 @@ import scalacss.ScalaCssReact._
 
 object GeotrellisAdminViewer {
 
-  case class State(showModal: Boolean = true)
+  case class State(showModal: Boolean = true, showJSON: Boolean = false)
 
   class Backend($: BackendScope[ModelProxy[RootModel], State]) {
 
@@ -33,6 +33,14 @@ object GeotrellisAdminViewer {
             ^.onClick --> $.modState(_.copy(showModal = true)),
             "Map Settings"
           ),
+          <.button(
+            BootstrapStyles.buttonDefaultBlock,
+            ^.onClick --> $.modState(s => s.copy(showJSON = !s.showJSON)),
+            "Metadata JSON"
+          ),
+          (if (state.showJSON) {
+            <.code("This is code")
+          } else ""),
           <.div(
             props.connect(_.displayM)(InfoPanel(_))
           ),

--- a/client/src/main/scala/geotrellis/admin/client/routes/GeotrellisAdminViewer.scala
+++ b/client/src/main/scala/geotrellis/admin/client/routes/GeotrellisAdminViewer.scala
@@ -1,6 +1,7 @@
 package geotrellis.admin.client.routes
 
 import diode.react._
+import diode.react.ReactPot._
 import geotrellis.admin.client.circuit._
 import geotrellis.admin.client.components._
 import geotrellis.admin.client.components.map._
@@ -39,7 +40,7 @@ object GeotrellisAdminViewer {
             "Metadata JSON"
           ),
           (if (state.showJSON) {
-            <.code("This is code")
+            props().displayM.rawMetadata.render(j => <.pre(j))
           } else ""),
           <.div(
             props.connect(_.displayM)(InfoPanel(_))

--- a/server/src/main/scala/geotrellis/admin/server/AdminActor.scala
+++ b/server/src/main/scala/geotrellis/admin/server/AdminActor.scala
@@ -151,10 +151,8 @@ trait AdminRoutes extends HttpService with CORSSupport {
        */
       getMetadata(id).map(_.toJson.asJsObject).recover({
         case e: Throwable => {
-          val resp: JsValue = Try(attributeStore.read[JsValue](id, "metadata"))
-            .getOrElse(JsString("Error: No metadata for this layer/zoom."))
-
-          JsObject("metadata" -> resp)
+          Try(attributeStore.read[JsObject](id, "metadata"))
+            .getOrElse(JsObject("error" -> JsString("No metadata for this layer/zoom.")))
         }
       })
     }


### PR DESCRIPTION
## TODO
- [x] Alter `gt/metadata` endpoint to serve raw, broken JSON if possible
- [x] Add "Raw Metadata" button to client

## Motivation
Layers may have broken metadata that no longer conform to the `TileLayerMetadata[SpatialKey]` JSON format. To debug layers like these, we'd like a way to easily view their raw metadata as JSON through the viewer client.